### PR TITLE
Add predefined linkage functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Downloads][downloads-image]][downloads-url]
 [![Gittip][gittip-image]][gittip-url]
 
-Hierarchical clustering based on [How to Explain Hierarchical Clustering](http://www.analytictech.com/networks/hiclus.htm).
+Agglomerative Hierarchical clustering based on [How to Explain Hierarchical Clustering](http://www.analytictech.com/networks/hiclus.htm).
 
 ## Example
 
@@ -70,7 +70,7 @@ Options:
 
 - `.input <Array> (required)` - input array
 - `.distance <Function> (required)` - distance function
-- `.linkage <Function> (required)` - linkage function
+- `.linkage <Function> (required)` - linkage function or string of 'single', 'complete or 'average'
 - `.minClusters <Integer> (1)` - number of clusters you want to iterate to
 - `.maxLinkage <Integer> (Infinity)` - maximum linkage until you stop iteration
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,17 @@ function Cluster(options) {
   if (!Array.isArray(options.input)) throw new TypeError('input must be an array')
   if (!options.input.length) throw new Error('input must not be empty')
   if (typeof options.distance !== 'function') throw new TypeError('invalid distance function')
+
+  var linkageFns = {
+    'single': singleLink,
+    'complete': completeLink,
+    'average': averageLink
+  }
+
+  if(typeof options.linkage === 'string') options.linkage = linkageFns[options.linkage]
+
   if (typeof options.linkage !== 'function') throw new TypeError('invalid linkage function')
+
 
   this.input = options.input
   this.distance = options.distance
@@ -123,4 +133,23 @@ function createDistanceArray(input, distance) {
   }
 
   return matrix
+}
+
+/*
+ * Predefined linkage functions
+ */
+
+function singleLink(distances) {
+  return Math.min.apply(null, distances)
+}
+
+function completeLink(distances) {
+  return Math.max.apply(null, distances)
+}
+
+function averageLink(distances) {
+  var sum = distances.reduce(function (a, b) {
+    return a + b
+  })
+  return sum / distances.length
 }

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,42 @@ describe('Colors', function () {
     assert(last.clusters[0].length === 7)
   })
 
+  it('should cluster (predefined single)', function () {
+    var levels = cluster({
+      input: colors,
+      distance: euclideanDistance,
+      linkage: 'single',
+    })
+    assert(levels.length === 7)
+    var last = levels[levels.length - 1]
+    assert(last.clusters.length === 1)
+    assert(last.clusters[0].length === 7)
+  })
+
+  it('should cluster (predefined complete)', function () {
+    var levels = cluster({
+      input: colors,
+      distance: euclideanDistance,
+      linkage: 'single',
+    })
+    assert(levels.length === 7)
+    var last = levels[levels.length - 1]
+    assert(last.clusters.length === 1)
+    assert(last.clusters[0].length === 7)
+  })
+
+  it('should cluster (predefined average)', function () {
+    var levels = cluster({
+      input: colors,
+      distance: euclideanDistance,
+      linkage: 'single',
+    })
+    assert(levels.length === 7)
+    var last = levels[levels.length - 1]
+    assert(last.clusters.length === 1)
+    assert(last.clusters[0].length === 7)
+  })
+
   it('should support min clusters', function () {
     var levels = cluster({
       input: colors,


### PR DESCRIPTION
I added three linkage functions `average, single, complete`, which can be used by passing in a string with the names to the linkage argument instead of a function as suggested here #2.

I duplicated the tests for every functions, not a good test, but at least ensures that they are working.
